### PR TITLE
Migrate Dockerfile to Bookworm (#26802)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
-# This needs to be bullseye-slim because the Ruby image is built on bullseye-slim
-ARG NODE_VERSION="16.20-bullseye-slim"
+# This needs to be bookworm-slim because the Ruby image is built on bookworm-slim
+ARG NODE_VERSION="16.20-bookworm-slim"
 
 FROM ghcr.io/moritzheiber/ruby-jemalloc:3.2.2-slim as ruby
 FROM node:${NODE_VERSION} as build
@@ -20,7 +20,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential \
         git \
         libicu-dev \
-        libidn11-dev \
+        libidn-dev \
         libpq-dev \
         libjemalloc-dev \
         zlib1g-dev \
@@ -60,13 +60,13 @@ RUN apt-get update && \
     apt-get -y --no-install-recommends install whois \
         wget \
         procps \
-        libssl1.1 \
+        libssl3 \
         libpq5 \
         imagemagick \
         ffmpeg \
         libjemalloc2 \
-        libicu67 \
-        libidn11 \
+        libicu72 \
+        libidn12 \
         libyaml-0-2 \
         file \
         ca-certificates \


### PR DESCRIPTION
I propose to cherry-pick this commit from mastodon/mastodon that updates the Dockerfile.

Reason:
I am trying to launch closed-social/mastodon on Ubuntu 20.04 and Docker version 27.0.3.
When trying to build an image out of the Dockerfile using `docker build -t closed-social .`, I get the following errors:
```
36.61 /opt/ruby/bin/ruby: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /opt/ruby/bin/ruby)
36.61 /opt/ruby/bin/ruby: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.35' not found (required by /opt/ruby/lib/libruby.so.3.2)
36.61 /opt/ruby/bin/ruby: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /opt/ruby/lib/libruby.so.3.2)
36.61 /opt/ruby/bin/ruby: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /opt/ruby/lib/libruby.so.3.2)
36.61 /opt/ruby/bin/ruby: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /opt/ruby/lib/libruby.so.3.2)
------
Dockerfile:19
```
Updating the Dockerfile according to the attached commit resolves this issue.